### PR TITLE
Make pdf-viewer show page numbers in Index panel correctly

### DIFF
--- a/Thesis.cls
+++ b/Thesis.cls
@@ -324,6 +324,7 @@
 \addtocounter{secnumdepth}{1}
 \setcounter{tocdepth}{2}
 \newcommand\addtotoc[1]{
+  \phantomsection
   \addcontentsline{toc}{chapter}{#1}
 }
 \renewcommand\tableofcontents{


### PR DESCRIPTION
Before the change, when one opened the generated Thesis.pdf with any pdf-viewer (I tried evince and okular) the Index panel showed the same page number 'i' for Declaration, Abstract and Acknowledgements and also the same page number '4' for List of Figures, List of Tables and Bibliography. Now with the change, the Index panel shows the page numbers properly: the same way they are in the Contents. 